### PR TITLE
use zod brand

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@testing-library/react": "16.0.1",
     "@types/babel__core": "7.20.5",
     "@types/jest": "29.5.14",
-    "@types/node": "20.17.1",
+    "@types/node": "20.17.2",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
     "@vitejs/plugin-react": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
     "@vitejs/plugin-react": "4.3.3",
-    "@vitest/coverage-v8": "2.1.3",
+    "@vitest/coverage-v8": "2.1.4",
     "chokidar-cli": "3.0.0",
     "convex-test": "0.0.33",
     "eslint": "9.13.0",
@@ -55,6 +55,6 @@
     "npm-run-all2": "7.0.1",
     "typescript": "5.6.3",
     "vite": "5.4.10",
-    "vitest": "2.1.3"
+    "vitest": "2.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@testing-library/react": "16.0.1",
     "@types/babel__core": "7.20.5",
     "@types/jest": "29.5.14",
-    "@types/node": "20.17.0",
+    "@types/node": "20.17.1",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
     "@vitejs/plugin-react": "4.3.3",

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convex-helpers",
-  "version": "0.1.63-alpha.0",
+  "version": "0.1.63",
   "description": "A collection of useful code to complement the official convex package.",
   "type": "module",
   "bin": {

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convex-helpers",
-  "version": "0.1.63",
+  "version": "0.1.64-alpha.0",
   "description": "A collection of useful code to complement the official convex package.",
   "type": "module",
   "bin": {

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convex-helpers",
-  "version": "0.1.62",
+  "version": "0.1.63-alpha.0",
   "description": "A collection of useful code to complement the official convex package.",
   "type": "module",
   "bin": {

--- a/packages/convex-helpers/server/zod.test.ts
+++ b/packages/convex-helpers/server/zod.test.ts
@@ -13,7 +13,7 @@ import { describe, expect, test } from "vitest";
 import { modules } from "./setup.test.js";
 import { zCustomQuery, zid, zodToConvexFields } from "./zod.js";
 import { customCtx } from "./customFunctions.js";
-import { v } from "convex/values";
+import { v, VString } from "convex/values";
 import { z } from "zod";
 
 // This is an example of how to make a version of `zid` that
@@ -312,7 +312,7 @@ test("zod kitchen sink", async () => {
     effect: "effect",
     optional: undefined,
     nullable: null,
-    branded: "branded",
+    branded: "branded" as string & z.BRAND<"branded">,
     default: undefined,
     readonly: { a: "1", b: 2 },
     pipeline: 0,
@@ -555,7 +555,7 @@ assert(
       bi: v.int64(),
       bool: v.boolean(),
       literal: v.literal("hi"),
-      branded: v.string(),
+      branded: v.string() as VString<string & z.BRAND<"branded">>,
     },
   ),
 );

--- a/packages/convex-helpers/server/zod.test.ts
+++ b/packages/convex-helpers/server/zod.test.ts
@@ -37,6 +37,10 @@ export const kitchenSinkValidator = {
   array: z.array(z.string()),
   object: z.object({ a: z.string(), b: z.number() }),
   objectWithOptional: z.object({ a: z.string(), b: z.number().optional() }),
+  record: z.record(
+    z.union([z.string(), zid("users")]),
+    z.union([z.number(), z.string()]),
+  ),
   union: z.union([z.string(), z.number()]),
   discriminatedUnion: z.discriminatedUnion("kind", [
     z.object({ kind: z.literal("a"), a: z.string() }),
@@ -303,6 +307,7 @@ test("zod kitchen sink", async () => {
     array: ["1", "2"],
     object: { a: "1", b: 2 },
     objectWithOptional: { a: "1" },
+    record: { a: 1 },
     union: 1,
     discriminatedUnion: { kind: "a" as const, a: "1" },
     literal: "hi" as const,
@@ -397,6 +402,16 @@ test("zod kitchen sink", async () => {
         },
         optional: false,
       },
+      objectWithOptional: {
+        fieldType: {
+          type: "object",
+          value: {
+            a: { fieldType: { type: "string" }, optional: false },
+            b: { fieldType: { type: "number" }, optional: true },
+          },
+        },
+        optional: false,
+      },
       optional: {
         fieldType: {
           type: "object",
@@ -417,6 +432,21 @@ test("zod kitchen sink", async () => {
           },
         },
         optional: false,
+      },
+      record: {
+        fieldType: {
+          keys: {
+            type: "union",
+            value: [{ type: "string" }, { tableName: "users", type: "id" }],
+          },
+          type: "record",
+          values: {
+            fieldType: {
+              type: "union",
+              value: [{ type: "number" }, { type: "string" }],
+            },
+          },
+        },
       },
       tuple: {
         fieldType: {
@@ -535,6 +565,7 @@ assert(
       nan: z.nan(),
       optional: z.number().optional(),
       optional2: z.optional(z.number()),
+      record: z.record(z.string(), z.number()),
       default: z.number().default(0),
       nullable: z.number().nullable(),
       null: z.null(),
@@ -549,6 +580,7 @@ assert(
       nan: v.number(),
       optional: v.optional(v.number()),
       optional2: v.optional(v.number()),
+      record: v.record(v.string(), v.number()),
       default: v.optional(v.number()),
       nullable: v.union(v.number(), v.null()),
       null: v.null(),

--- a/packages/convex-helpers/server/zod.ts
+++ b/packages/convex-helpers/server/zod.ts
@@ -20,6 +20,7 @@ import {
   VOptional,
   VObject,
   Validator,
+  VRecord,
 } from "convex/values";
 import {
   FunctionVisibility,
@@ -583,36 +584,66 @@ type ConvexValidatorFromZod<Z extends z.ZodTypeAny> =
                                                     ConvexValidatorFromZod<Inner>
                                                   >
                                                 : never
-                                              : Z extends z.ZodReadonly<
-                                                    infer Inner
+                                              : Z extends z.ZodRecord<
+                                                    infer K,
+                                                    infer V
                                                   >
-                                                ? ConvexValidatorFromZod<Inner>
-                                                : Z extends z.ZodPipeline<
-                                                      infer Inner,
-                                                      any
-                                                    > // Validate input type
+                                                ? K extends
+                                                    | z.ZodString
+                                                    | Zid<string>
+                                                    | z.ZodUnion<
+                                                        [
+                                                          (
+                                                            | z.ZodString
+                                                            | Zid<string>
+                                                          ),
+                                                          (
+                                                            | z.ZodString
+                                                            | Zid<string>
+                                                          ),
+                                                          ...(
+                                                            | z.ZodString
+                                                            | Zid<string>
+                                                          )[],
+                                                        ]
+                                                      >
+                                                  ? VRecord<
+                                                      z.RecordType<
+                                                        ConvexValidatorFromZod<K>["type"],
+                                                        ConvexValidatorFromZod<V>["type"]
+                                                      >,
+                                                      ConvexValidatorFromZod<K>,
+                                                      ConvexValidatorFromZod<V>
+                                                    >
+                                                  : never
+                                                : Z extends z.ZodReadonly<
+                                                      infer Inner
+                                                    >
                                                   ? ConvexValidatorFromZod<Inner>
-                                                  : // Some that are a bit unknown
-                                                    // : Z extends z.ZodDate ? Validator<number>
-                                                    // : Z extends z.ZodSymbol ? Validator<symbol>
-                                                    // : Z extends z.ZodNever ? Validator<never>
-                                                    // : Z extends z.ZodIntersection<infer T, infer U>
-                                                    // ? Validator<
-                                                    //     ConvexValidatorFromZodValidator<T>["type"] &
-                                                    //       ConvexValidatorFromZodValidator<U>["type"],
-                                                    //     "required",
-                                                    //     ConvexValidatorFromZodValidator<T>["fieldPaths"] |
-                                                    //       ConvexValidatorFromZodValidator<U>["fieldPaths"]
-                                                    //   >
-                                                    // Is arraybuffer a thing?
-                                                    // Z extends z.??? ? Validator<ArrayBuffer> :
-                                                    // If/when Convex supports Record:
-                                                    // Z extends z.ZodRecord<infer K, infer V> ? RecordValidator<ConvexValidatorFromZodValidator<K>["type"], ConvexValidatorFromZodValidator<V>["type"]> :
-                                                    // Note: we don't handle z.undefined() in union, nullable, etc.
-                                                    // ? Validator<any, "required", string>
-                                                    // We avoid doing this catch-all to avoid over-promising on types
-                                                    // : Z extends z.ZodTypeAny
-                                                    never;
+                                                  : Z extends z.ZodPipeline<
+                                                        infer Inner,
+                                                        any
+                                                      > // Validate input type
+                                                    ? ConvexValidatorFromZod<Inner>
+                                                    : // Some that are a bit unknown
+                                                      // : Z extends z.ZodDate ? Validator<number>
+                                                      // : Z extends z.ZodSymbol ? Validator<symbol>
+                                                      // : Z extends z.ZodNever ? Validator<never>
+                                                      // : Z extends z.ZodIntersection<infer T, infer U>
+                                                      // ? Validator<
+                                                      //     ConvexValidatorFromZod<T>["type"] &
+                                                      //       ConvexValidatorFromZod<U>["type"],
+                                                      //     "required",
+                                                      //     ConvexValidatorFromZod<T>["fieldPaths"] |
+                                                      //       ConvexValidatorFromZod<U>["fieldPaths"]
+                                                      //   >
+                                                      // Is arraybuffer a thing?
+                                                      // Z extends z.??? ? Validator<ArrayBuffer> :
+                                                      // Note: we don't handle z.undefined() in union, nullable, etc.
+                                                      // ? Validator<any, "required", string>
+                                                      // We avoid doing this catch-all to avoid over-promising on types
+                                                      // : Z extends z.ZodTypeAny
+                                                      never;
 
 /**
  * Turn a Zod validator into a Convex Validator.
@@ -700,6 +731,22 @@ export function zodToConvex<Z extends z.ZodTypeAny>(
         return withDefault as ConvexValidatorFromZod<Z>;
       }
       return v.optional(withDefault) as ConvexValidatorFromZod<Z>;
+    case "ZodRecord":
+      const keyType = zodToConvex(
+        zod._def.keyType,
+      ) as ConvexValidatorFromZod<Z>;
+      function ensureStringOrId(v: GenericValidator) {
+        if (v.kind === "union") {
+          v.members.map(ensureStringOrId);
+        } else if (v.kind !== "string" && v.kind !== "id") {
+          throw new Error("Record keys must be strings or ids: " + v.kind);
+        }
+      }
+      ensureStringOrId(keyType);
+      return v.record(
+        keyType,
+        zodToConvex(zod._def.valueType) as ConvexValidatorFromZod<Z>,
+      ) as unknown as ConvexValidatorFromZod<Z>;
     case "ZodReadonly":
       return zodToConvex(zod._def.innerType) as ConvexValidatorFromZod<Z>;
     case "ZodPipeline":
@@ -713,7 +760,6 @@ export function zodToConvex<Z extends z.ZodTypeAny>(
     // case "ZodNever":
     // case "ZodVoid":
     // case "ZodIntersection":
-    // case "ZodRecord":
     // case "ZodMap":
     // case "ZodSet":
     // case "ZodFunction":


### PR DESCRIPTION
I'm going to keep the `brandedString` separate from the zod branding for now, so folks not using zod don't have to install it as a peer dependency. how does this look / work for you?